### PR TITLE
fix maintainers report viz

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+extend-ignore =
+    E203

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+.ipynb_checkpoints


### PR DESCRIPTION
The previous script had some issues:

1. Each "Issue" is also a PR, but not the other way around :shrug: needed to add a conditional to deal with that
1. Search was limited in time, missing e.g., issues that were opened in March but closed in September
1. Mindate needed `>=` ... not `>`

Also added a log for debugging --> the results now correspond exactly to the GitHub Pulse.

Drawback: This script needs very long to run ... but as we'll only run it once a month, that's fine for me. Having that said, perhaps we can add a CI job at some point, so we'll only have to download the image from the artifacts tab :-)